### PR TITLE
Avoid ConcurrentModificationException on Restart

### DIFF
--- a/src/main/java/org/spigotmc/RestartCommand.java
+++ b/src/main/java/org/spigotmc/RestartCommand.java
@@ -41,10 +41,14 @@ public class RestartCommand extends Command
                 System.out.println( "Attempting to restart with " + SpigotConfig.restartScript );
 
                 // Kick all players
-                for ( net.minecraft.entity.player.EntityPlayerMP p : (List< net.minecraft.entity.player.EntityPlayerMP>) net.minecraft.server.MinecraftServer.getServer().getConfigurationManager().playerEntityList )
+                for ( Object o :  net.minecraft.server.MinecraftServer.getServer().getConfigurationManager().playerEntityList.toArray() )
                 {
-                    p.playerNetServerHandler.kickPlayerFromServer(SpigotConfig.restartMessage);
-                    p.playerNetServerHandler.netManager.isChannelOpen();
+                    if(o instanceof net.minecraft.entity.player.EntityPlayerMP)
+                    {
+                        net.minecraft.entity.player.EntityPlayerMP mp = ( net.minecraft.entity.player.EntityPlayerMP)o;
+                        mp.playerNetServerHandler.kickPlayerFromServer(SpigotConfig.restartMessage);
+                        mp.playerNetServerHandler.netManager.isChannelOpen();
+                    }
                 }
                 // Give the socket a chance to send the packets
                 try


### PR DESCRIPTION
Encountered a problem where running /restart can issue a ConcurrentModificationException and the server will fail to restart.

Use the underlying array object to avoid this problem.